### PR TITLE
Fix incorrect require_relative path in DefaultContextEventHandler class

### DIFF
--- a/lib/default_context_event_handler.rb
+++ b/lib/default_context_event_handler.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "context_data_provider"
+require_relative "context_event_handler"
 
 class DefaultContextEventHandler < ContextDataProvider
   attr_accessor :client


### PR DESCRIPTION
Description:

This PR corrects the `require_relative` statement in the `DefaultContextEventHandler` class. The original code mistakenly required `context_data_provider` instead of the correct `context_event_handler`. This fix ensures that the proper file is referenced, thereby preventing any potential issues related to incorrect file loading and improving the reliability of the code in the future.
